### PR TITLE
Prevent printWarning from being called on component setup

### DIFF
--- a/src/vue-portable-text.vue
+++ b/src/vue-portable-text.vue
@@ -14,7 +14,7 @@ function noop() {
 }
 
 const props = withDefaults(defineProps<PortableTextProps<B>>(), {
-  onMissingComponent: printWarning,
+  onMissingComponent: () => printWarning,
 });
 
 const handleMissingComponent = props.onMissingComponent || noop;


### PR DESCRIPTION
As printWarning is a function it was being called by withDefaults whenever the component was created.